### PR TITLE
Initial experiments: update vs signal+query

### DIFF
--- a/run/experiments/signalquerypoll/experiment.go
+++ b/run/experiments/signalquerypoll/experiment.go
@@ -1,0 +1,86 @@
+package signalquerypoll
+
+import (
+	"context"
+
+	"time"
+
+	. "github.com/dandavison/temporal-latency-experiments/must"
+	"github.com/dandavison/temporal-latency-experiments/tle"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	sdklog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	SignalName     = "my-signal"
+	QueryName      = "my-query"
+	DoneSignalName = "Done"
+	workflowID     = "my-workflow-id"
+)
+
+// Send a signal and immediately start executing queries until a query result is
+// received indicating that it read the signal's writes to local workflow state.
+func Run(c client.Client, l sdklog.Logger, iterations int) tle.Results {
+	ctx := context.Background()
+	Must(c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    workflowID,
+		TaskQueue:             tle.TaskQueue,
+		WorkflowIDReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+	}, MyWorkflow))
+
+	latencies := []int64{}
+	polls := []int{}
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+
+		go Must1(c.SignalWorkflow(ctx, workflowID, "", SignalName, i))
+
+		for j := 1; ; j++ {
+			queryResult := Must(c.QueryWorkflow(ctx, workflowID, "", QueryName))
+			var result int
+			Must1(queryResult.Get(&result))
+			if result == i+1 {
+				polls = append(polls, j)
+				break
+			}
+		}
+		latency := time.Since(start).Nanoseconds()
+		latencies = append(latencies, latency)
+	}
+	Must1(c.SignalWorkflow(ctx, workflowID, "", DoneSignalName, nil))
+
+	return tle.Results{
+		LatenciesNs: latencies,
+		Polls:       polls,
+	}
+}
+
+func MyWorkflow(ctx workflow.Context) (int, error) {
+	counter := 0
+
+	workflow.SetQueryHandler(ctx, QueryName, func() (int, error) {
+		return counter, nil
+	})
+
+	ch := workflow.GetSignalChannel(ctx, SignalName)
+
+	sel := workflow.NewSelector(ctx)
+	sel.AddReceive(ch, func(c workflow.ReceiveChannel, more bool) {
+		var signal int
+		c.Receive(ctx, &signal)
+		counter++
+	})
+
+	doneCh := workflow.GetSignalChannel(ctx, DoneSignalName)
+
+	for {
+		sel.Select(ctx)
+		if doneCh.ReceiveAsync(nil) {
+			break
+		}
+	}
+
+	return counter, nil
+}

--- a/run/experiments/update/experiment.go
+++ b/run/experiments/update/experiment.go
@@ -1,0 +1,69 @@
+package update
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	. "github.com/dandavison/temporal-latency-experiments/must"
+	"github.com/dandavison/temporal-latency-experiments/tle"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	sdklog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	UpdateName     = "my-update"
+	DoneSignalName = "Done"
+	workflowID     = "my-workflow-id"
+)
+
+// Execute an update (i.e., send it and wait for the result).
+func Run(c client.Client, l sdklog.Logger, iterations int) tle.Results {
+	ctx := context.Background()
+	Must(c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    workflowID,
+		TaskQueue:             tle.TaskQueue,
+		WorkflowIDReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+	}, MyWorkflow))
+
+	latencies := []int64{}
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		u := Must(c.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+			WorkflowID:   workflowID,
+			UpdateName:   UpdateName,
+			UpdateID:     strconv.Itoa(i),
+			WaitForStage: client.WorkflowUpdateStageCompleted,
+		}))
+
+		var updateResult int
+		Must1(u.Get(ctx, &updateResult))
+
+		latency := time.Since(start).Nanoseconds()
+		latencies = append(latencies, latency)
+
+	}
+	Must1(c.SignalWorkflow(ctx, workflowID, "", DoneSignalName, nil))
+
+	return tle.Results{
+		LatenciesNs: latencies,
+	}
+}
+
+func MyWorkflow(ctx workflow.Context) (int, error) {
+	counter := 0
+	err := workflow.SetUpdateHandler(
+		ctx,
+		UpdateName,
+		func(ctx workflow.Context, val int) (int, error) {
+			counter += val
+			return counter, nil
+		})
+	if err != nil {
+		return 0, err
+	}
+	workflow.GetSignalChannel(ctx, DoneSignalName).Receive(ctx, nil)
+	return counter, nil
+}

--- a/run/main.go
+++ b/run/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	. "github.com/dandavison/temporal-latency-experiments/must"
+	"github.com/dandavison/temporal-latency-experiments/tle"
+	"github.com/dandavison/tle/experiments/signalquerypoll"
+	"github.com/dandavison/tle/experiments/update"
+	"go.temporal.io/sdk/client"
+	sdklog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/worker"
+)
+
+var experiments = map[string]func(client.Client, sdklog.Logger, int) tle.Results{
+	"update":          update.Run,
+	"signalquerypoll": signalquerypoll.Run,
+}
+
+var workflows = map[string]interface{}{
+	"update":          update.MyWorkflow,
+	"signalquerypoll": signalquerypoll.MyWorkflow,
+}
+
+func main() {
+	l := sdklog.NewStructuredLogger(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
+	run, workflow, iterations, cc := parseArguments()
+	c := makeClient(cc, l)
+	defer c.Close()
+	wo := startWorker(c, workflow)
+	defer wo.Stop()
+
+	r := run(c, l, iterations)
+
+	fmt.Println(string(Must(json.MarshalIndent(r, "", "  "))))
+}
+
+func makeClient(cc *ClientConfig, l sdklog.Logger) client.Client {
+	if cc == nil {
+		return Must(client.Dial(client.Options{Logger: l}))
+	}
+	cert := Must(tls.LoadX509KeyPair(cc.ClientCertPath, cc.ClientKeyPath))
+	return Must(client.Dial(client.Options{
+		HostPort:  cc.HostPort,
+		Namespace: cc.Namespace,
+		ConnectionOptions: client.ConnectionOptions{
+			TLS: &tls.Config{Certificates: []tls.Certificate{cert}},
+		},
+		Logger: l,
+	}))
+}
+
+func startWorker(c client.Client, workflow interface{}) worker.Worker {
+	wo := worker.New(c, tle.TaskQueue, worker.Options{})
+	wo.RegisterWorkflow(workflow)
+	Must1(wo.Start())
+	return wo
+}
+
+type ClientConfig struct {
+	ClientKeyPath  string
+	ClientCertPath string
+	HostPort       string
+	Namespace      string
+}
+
+func parseArguments() (func(client.Client, sdklog.Logger, int) tle.Results, interface{}, int, *ClientConfig) {
+	iterations := flag.Int("iterations", 1, "Number of iterations")
+	experimentName := flag.String("experiment", "", "Experiment to run")
+
+	var cc = new(ClientConfig)
+	flag.StringVar(&cc.ClientKeyPath, "client-key", "", "Path to client key")
+	flag.StringVar(&cc.ClientCertPath, "client-cert", "", "Path to client cert")
+	flag.StringVar(&cc.HostPort, "address", "", "Address of the Temporal server")
+	flag.StringVar(&cc.Namespace, "namespace", "", "Namespace of the Temporal server")
+
+	flag.Parse()
+
+	if cc.IsZero() {
+		cc = nil
+	} else if cc.ClientKeyPath == "" || cc.ClientCertPath == "" || cc.HostPort == "" || cc.Namespace == "" {
+		panic(fmt.Sprintf("If any client config flag is set, all must be set: %+v", cc))
+	}
+
+	if *experimentName == "" {
+		panic("Experiment name is required")
+	}
+	run, ok := experiments[*experimentName]
+	if !ok {
+		panic("Experiment not found")
+	}
+	workflow, ok := workflows[*experimentName]
+	if !ok {
+		panic("Workflow not found")
+	}
+	fmt.Fprintf(os.Stderr, "Running experiment %s\n", *experimentName)
+	return run, workflow, *iterations, cc
+}
+
+func (c *ClientConfig) IsZero() bool {
+	return c.ClientKeyPath == "" && c.ClientCertPath == "" && c.HostPort == "" && c.Namespace == ""
+}


### PR DESCRIPTION
This is the initial implementation of two end-to-end latency experiments. In both cases the update/signal handlers mutate local workflow state: they do not schedule an activity or otherwise generate commands.

**"update"**
Time from client sending update to client receiving update result.

**"signalquerypoll"**
The client sends a signal and immediately starts polling with queries.
Time measured is time from sending signal to receiving the first query result that reads the signals writes.
In practice, the query always makes it into the first WFT so there is only 1 "poll".